### PR TITLE
Install neovim

### DIFF
--- a/ansible/bin/dotfiles
+++ b/ansible/bin/dotfiles
@@ -62,3 +62,5 @@ cd "$DOTFILES_DIRECTORY"
 
 ansible-playbook --diff -K "$DOTFILES_DIRECTORY/main.yml"
 
+# We can pass -C flag to ansible-playbook to enable dry-run which means to run the playbook without changing anything for testing purposes.
+

--- a/ansible/bin/dotfiles
+++ b/ansible/bin/dotfiles
@@ -18,6 +18,7 @@ if ! [ -x "$(command -v ansible)" ]; then
 	sudo apt install software-properties-common
 	sudo add-apt-repository --yes --update ppa:ansible/ansible
 	sudo apt install ansible -y
+	pip install resolvelib==0.5.3
 else
 	echo "Ansible already installed." 
 fi
@@ -51,9 +52,9 @@ fi
 
 if [[ -f "$DOTFILES_DIRECTORY/requirements.yml" ]]; then
 
-	cd $DOTFILES_DIRECTORY
+	cd "$DOTFILES_DIRECTORY"
 
-	ansible-galaxy install -r requirements.yml
+	ansible-galaxy install -r "$DOTFILES_DIRECTORY/requirements.yml"
 
 fi
 

--- a/main.yml
+++ b/main.yml
@@ -5,4 +5,5 @@
 
   tasks:
     - import_tasks: tasks/essential.yml
+    - import_tasks: tasks/neovim.yml
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.general

--- a/tasks/essential.yml
+++ b/tasks/essential.yml
@@ -11,3 +11,10 @@
       - tmux
       - neofetch
     state: latest
+
+- name: Install github3 library
+  pip:
+    name:
+      - github3.py
+    state: latest
+

--- a/tasks/neovim.yml
+++ b/tasks/neovim.yml
@@ -1,0 +1,25 @@
+---
+- name: Get neovim latest stable release
+  community.general.github_release:
+    user: neovim
+    repo: neovim
+    action: latest_release
+  register: neovim_latest_version # register is like setting a variable
+
+- name: Report neovim lastest release
+  debug:
+    msg: "Latest neovim version is {{ neovim_latest_version['tag'] }}"
+
+- name: Download neovim {{ neovim_latest_version['tag'] }}
+  get_url:
+    url: https://github.com/neovim/neovim/releases/download/{{ neovim_latest_version['tag'] }}/nvim-linux64.deb
+    dest: /home/manquito/Downloads
+
+- name: Install neovim {{ neovim_latest_version['tag'] }}
+  apt:
+    deb: /home/manquito/Downloads/nvim-linux64.deb
+
+- name: Remove neovim {{ neovim_latest_version['tag'] }} deb file
+  file:
+    state: absent
+    path: /home/manquito/Downloads/nvim-linux64.deb


### PR DESCRIPTION
This PR setup up ansible to install neovim's latest release. It also sets up some dependencies for ansible-galaxy and github_release module.