### PR TITLE
Install zsh, oh-my-zsh and zsh-autosuggestions

### DIFF
--- a/ansible/arch/main.yml
+++ b/ansible/arch/main.yml
@@ -7,3 +7,4 @@
     - import_tasks: tasks/nerd-fonts.yml
     - import_tasks: tasks/astro-vim.yml
     - import_tasks: tasks/i3gaps.yml
+    - import_tasks: tasks/zsh.yml

--- a/ansible/arch/tasks/zsh.yml
+++ b/ansible/arch/tasks/zsh.yml
@@ -1,0 +1,22 @@
+---
+- name: Install zsh
+  ansible.builtin.package:
+    name: zsh
+
+- name: Change default shell to zsh
+  ansible.builtin.shell: chsh -s $(which zsh)
+
+- name: Check of .oh-my-zsh exists
+  ansible.builtin.stat:
+    path: /home/manquito/.oh-my-zsh/
+  register: oh_my_zsh_exists
+
+- name: Install Oh-My-Zsh
+  ansible.builtin.shell: sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+  when: not oh_my_zsh_exists.stat.exists
+
+
+- name: Install zsh-autosuggestions
+  ansible.builtin.git:
+    repo: https://github.com/zsh-users/zsh-autosuggestions
+    dest: /home/manquito/.oh-my-zsh/plugins/zsh-autosuggestions


### PR DESCRIPTION
This PR installs the following packages to Arch:

- `zsh`
- `oh-my-zsh`
- `zsh-autosuggestions`