### PR TITLE
use ansible.builtin.package instead of community.general.pacman

### DIFF
--- a/ansible/arch/tasks/bat.yml
+++ b/ansible/arch/tasks/bat.yml
@@ -1,4 +1,4 @@
 ---
 - name: Install bat
-  community.general.pacman:
+  ansible.builtin.package:
     name: bat

--- a/ansible/arch/tasks/exa.yml
+++ b/ansible/arch/tasks/exa.yml
@@ -1,4 +1,4 @@
 ---
 - name: Install exa
-  community.general.pacman:
+  ansible.builtin.package:
     name: exa

--- a/ansible/arch/tasks/feh.yml
+++ b/ansible/arch/tasks/feh.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install feh
-  community.general.pacman:
+  ansible.builtin.package:
     name: feh
 
 

--- a/ansible/arch/tasks/polybar.yml
+++ b/ansible/arch/tasks/polybar.yml
@@ -1,4 +1,4 @@
 ---
 - name: Install polybar
-  community.general.pacman:
+  ansible.builtin.package:
     name: polybar

--- a/ansible/arch/tasks/rofi.yml
+++ b/ansible/arch/tasks/rofi.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install rofi
-  community.general.pacman:
+  ansible.builtin.package:
     name: rofi
 


### PR DESCRIPTION
This PR replaces the use of `community.general.pacman` to `ansible.builtin.package`