### PR TITLE
Add pip dependency

### DIFF
--- a/ansible/arch/tasks/essential.yml
+++ b/ansible/arch/tasks/essential.yml
@@ -11,6 +11,7 @@
       - neofetch
       - neovim
       - stow
+      - python-pip
 
 - name: Install github3 library
   ansible.builtin.pip:


### PR DESCRIPTION
This PR fixes github3 not having `pip` dependency.